### PR TITLE
Adds meta info to agent info that is opaque to the bootstrap sever

### DIFF
--- a/src/agent_info/info.ts
+++ b/src/agent_info/info.ts
@@ -170,6 +170,8 @@ export const AgentInfo = D.type({
  signed_at_ms: SignedAtMsSafe,
  // Milliseconds after which this info expires relative to the signature time.
  expires_after_ms: ExpiresAfterMsSafe,
+ // Information that is not used for bootstrapping.
+ meta_info: MP.messagePackData,
 })
 export type AgentInfo = D.TypeOf<typeof AgentInfo>
 

--- a/test/fixture/agents.ts
+++ b/test/fixture/agents.ts
@@ -42,6 +42,7 @@ export const aliceAgentVapor:AgentInfo = {
  urls: ['https://example.com', 'https://foo.com'],
  signed_at_ms: Date.now(),
  expires_after_ms: 100000,
+ meta_info: new Uint8Array(0),
 }
 export const aliceAgentVaporSignedRaw:AgentInfoSignedRaw = {
  signature: Crypto.sign(encode(aliceAgentVapor), alice.secretKey),
@@ -55,6 +56,7 @@ export const aliceAgentWiki:AgentInfo = {
  urls: ["https://alice.com"],
  signed_at_ms: Date.now(),
  expires_after_ms: 150000,
+ meta_info: new Uint8Array(0),
 }
 export const aliceAgentWikiSignedRaw:AgentInfoSignedRaw = {
  signature: Crypto.sign(encode(aliceAgentWiki), alice.secretKey),
@@ -68,6 +70,7 @@ export const bobAgentVapor:AgentInfo = {
  urls: ["https://bob.com"],
  signed_at_ms: Date.now(),
  expires_after_ms: 100000,
+ meta_info: new Uint8Array(0),
 }
 export const bobAgentVaporSignedRaw:AgentInfoSignedRaw = {
  signature: Crypto.sign(encode(bobAgentVapor), bob.secretKey),


### PR DESCRIPTION
Maybe we should do some bounds checking on the amount of data in here to stop people from sending arbitrary amounts of bytes?