### PR TITLE
switch wrangler upload type to 'modules'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,18 +2,19 @@
   "name": "holochain-bootstrap",
   "version": "1.0.0",
   "description": "holochain bootstrap cloudflare worker",
-  "main": "dist/worker.production.js",
+  "main": "dist/worker.js",
   "scripts": {
     "build": "webpack",
     "dev": "NODE_ENV=development npm run build",
     "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts' 'test/**/*.ts'",
     "test:unit": "npx ts-mocha 'test/**/*.ts'",
-    "test:integration": "node ./run-integration-test.js",
+    "test:integration": "node ./run-integration-test.cjs",
     "test": "npm run format:check && npm run test:unit && npm run test:integration"
   },
   "author": "author",
   "license": "MIT OR Apache-2.0",
+  "type": "module",
   "devDependencies": {
     "@cloudflare/workers-types": "^3.3.1",
     "@cloudflare/wrangler": "^1.19.7",

--- a/run-integration-test.cjs
+++ b/run-integration-test.cjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// vim: set syntax=javascript:
+
 // This test script uses the `miniflare` cloudflare simulation library.
 // This simulator is run on the local machine with a connected KV store
 // named `BOOTSTRAP` just as a production cloudflare would.

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -1,0 +1,3 @@
+export class Ctx {
+  constructor(public request: Request, public BOOTSTRAP: KVNamespace) {}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
-import { eventDispatch } from './request/dispatch'
+import { Ctx } from './ctx'
+import { requestDispatch } from './request/dispatch'
 
-addEventListener('fetch', (event) => {
-  event.respondWith(eventDispatch(event))
-})
+export default {
+  async fetch(
+    request: Request,
+    env: { BOOTSTRAP: KVNamespace },
+  ): Promise<Response> {
+    const ctx = new Ctx(request, env.BOOTSTRAP)
+    return await requestDispatch(ctx)
+  },
+}

--- a/src/kv/get.ts
+++ b/src/kv/get.ts
@@ -1,3 +1,4 @@
+import { Ctx } from '../ctx'
 import * as MP from '../msgpack/msgpack'
 import { Key, agentKey } from '../kv/kv'
 import * as Kitsune from '../kitsune/kitsune'
@@ -11,11 +12,14 @@ import * as D from 'io-ts/Decoder'
 // - The signed agent info data, as signed by the agent, as messagepack data OR
 // - null encoded as messagepack if the key does not exist OR
 // - an error if there is some error
-export async function get(key: Key): Promise<MP.MessagePackData | Error> {
+export async function get(
+  key: Key,
+  ctx: Ctx,
+): Promise<MP.MessagePackData | Error> {
   try {
     let space = key.slice(0, Kitsune.spaceLength)
     let agent = key.slice(Kitsune.spaceLength)
-    let value = await BOOTSTRAP.get(agentKey(space, agent), 'arrayBuffer')
+    let value = await ctx.BOOTSTRAP.get(agentKey(space, agent), 'arrayBuffer')
     // Found values are already messagepack encoded but null won't be so we have to
     // manually encode it here.
     return value === null ? MP.encode(null) : new Uint8Array(value)

--- a/src/kv/list.ts
+++ b/src/kv/list.ts
@@ -1,3 +1,4 @@
+import { Ctx } from '../ctx'
 import * as Kitsune from '../kitsune/kitsune'
 import * as Base64 from '../base64/base64'
 import { pipe } from 'fp-ts/lib/pipeable'
@@ -18,6 +19,7 @@ function agentFromKey(prefix: Base64.Value, key: string): Kitsune.Agent {
 // Returns all pubkeys for all agents currently registered in the space.
 export async function list(
   space: Kitsune.Space,
+  ctx: Ctx,
 ): Promise<Array<Kitsune.Agent>> {
   let prefix = Base64.fromBytes(space)
   let keys: any[] = []
@@ -37,7 +39,7 @@ export async function list(
     }
 
     // This comes from cloudflare in the kv binding.
-    let list = await BOOTSTRAP.list(options)
+    let list = await ctx.BOOTSTRAP.list(options)
 
     more = !list.list_complete
     cursor = list.cursor

--- a/src/kv/put.ts
+++ b/src/kv/put.ts
@@ -1,3 +1,4 @@
+import { Ctx } from '../ctx'
 import * as MP from '../msgpack/msgpack'
 import * as AgentInfo from '../agent_info/info'
 import * as AgentSigned from '../agent_info/signed'
@@ -17,6 +18,7 @@ export const MAX_HOLD = 60 * 60 * 1000
 // Returns null if everything works and the put is successful.
 export async function put(
   agentInfoSignedRawData: MP.MessagePackData,
+  ctx: Ctx,
 ): Promise<E.Either<Error, unknown>> {
   try {
     let doPut = async (
@@ -41,7 +43,7 @@ export async function put(
         )
 
         // Cloudflare binds this global to the kv store.
-        await BOOTSTRAP.put(key, value, { expiration: expires })
+        await ctx.BOOTSTRAP.put(key, value, { expiration: expires })
         return E.right(null)
       } catch (e) {
         if (e instanceof Error) {

--- a/src/kv/random.ts
+++ b/src/kv/random.ts
@@ -1,3 +1,4 @@
+import { Ctx } from '../ctx'
 import * as D from 'io-ts/Decoder'
 import * as E from 'fp-ts/lib/Either'
 import * as Kitsune from '../kitsune/kitsune'
@@ -37,12 +38,13 @@ function* shuffle(array: any) {
 
 export async function random(
   query: Query,
+  ctx: Ctx,
 ): Promise<Array<MP.MessagePackData | Error>> {
   let { space, limit } = query
   // Need to be random over the complete list for the whole space even if we use
   // a generator to shuffle, otherwise we won't ever return agents after the
   // first page (1000 items on cloudflare).
-  let everyone = shuffle(await List.list(space))
+  let everyone = shuffle(await List.list(space, ctx))
   let keys = []
   let i = 0
   let k: Kitsune.Agent
@@ -56,6 +58,6 @@ export async function random(
     }
   }
   return await Promise.all(
-    keys.map((k) => Get.get(Uint8Array.from([...space, ...k]))),
+    keys.map((k) => Get.get(Uint8Array.from([...space, ...k]), ctx)),
   )
 }

--- a/src/op/now.ts
+++ b/src/op/now.ts
@@ -1,9 +1,11 @@
+import { Ctx } from '../ctx'
 import * as MP from '../msgpack/msgpack'
 
 // The `now` op does not interact with the kv store at all.
 // We can encompass all the logic as a native call, messagepack encoded.
 export const now = async (
   _: MP.MessagePackData,
+  _ctx: Ctx,
 ): Promise<MP.MessagePackData | Error> => {
   try {
     return MP.encode(Date.now())

--- a/src/op/put.ts
+++ b/src/op/put.ts
@@ -1,3 +1,4 @@
+import { Ctx } from '../ctx'
 import * as MP from '../msgpack/msgpack'
 import * as E from 'fp-ts/lib/Either'
 import * as KVPut from '../kv/put'
@@ -7,9 +8,10 @@ import * as KVPut from '../kv/put'
 // Returns messagepack null if successful or the error if there is an error.
 export async function put(
   input: MP.MessagePackData,
+  ctx: Ctx,
 ): Promise<MP.MessagePackData | Error> {
   try {
-    let p = await KVPut.put(input)
+    let p = await KVPut.put(input, ctx)
     if (E.isLeft(p)) {
       return p.left
     } else {

--- a/src/op/random.ts
+++ b/src/op/random.ts
@@ -1,3 +1,4 @@
+import { Ctx } from '../ctx'
 import * as D from 'io-ts/Decoder'
 import * as MP from '../msgpack/msgpack'
 import { pipe } from 'fp-ts/lib/pipeable'
@@ -9,13 +10,14 @@ import * as KVRandom from '../kv/random'
 // @see random as documented under kv.
 export async function random(
   input: MP.MessagePackData,
+  ctx: Ctx,
 ): Promise<MP.MessagePackData | Error> {
   try {
     let result = await pipe(
       KVRandom.QuerySafe.decode(input),
       E.mapLeft((v) => Error(JSON.stringify(v))),
       E.map(async (queryValue) => {
-        return MP.encode(await KVRandom.random(queryValue))
+        return MP.encode(await KVRandom.random(queryValue, ctx))
       }),
     )
     if (E.isLeft(result)) {

--- a/src/request/dispatch.ts
+++ b/src/request/dispatch.ts
@@ -1,12 +1,17 @@
+import { Ctx } from '../ctx'
 import { postHandler } from './post'
 
-export async function eventDispatch(event: FetchEvent): Promise<Response> {
-  if (event.request.method === 'POST') {
-    return postHandler(event)
+export async function requestDispatch(ctx: Ctx): Promise<Response> {
+  const method = ctx.request.method
+  const op = ctx.request.headers.get('X-Op') || ''
+  const input = new Uint8Array(await ctx.request.arrayBuffer())
+
+  if (method === 'POST') {
+    return postHandler(ctx, op, input)
   }
 
   // Respond with a simple pong for any GET to help with smoke testing.
-  if (event.request.method === 'GET') {
+  if (method === 'GET') {
     return new Response('OK')
   }
 

--- a/src/request/post.ts
+++ b/src/request/post.ts
@@ -1,20 +1,21 @@
+import { Ctx } from '../ctx'
 import { put } from '../op/put'
 import { random } from '../op/random'
 import { now } from '../op/now'
 import * as MP from '../msgpack/msgpack'
 
-const DISPATCH_HEADER: string = 'X-Op'
 const OP_PUT: string = 'put'
 const OP_RANDOM: string = 'random'
 const OP_NOW: string = 'now'
 
 async function handle(
-  f: (bytes: Uint8Array) => Promise<MP.MessagePackData | Error>,
+  f: (bytes: Uint8Array, ctx: Ctx) => Promise<MP.MessagePackData | Error>,
   input: MP.MessagePackData,
+  ctx: Ctx,
 ): Promise<Response> {
   // Every f needs to handle messagepack decoding itself so that the deserialized
   // object can sanity check itself.
-  let tryF = await f(input)
+  let tryF = await f(input, ctx)
 
   if (tryF instanceof Error) {
     console.error('messagepack input:', input.toString())
@@ -25,15 +26,18 @@ async function handle(
   return new Response(tryF)
 }
 
-export async function postHandler(event: FetchEvent): Promise<Response> {
-  let input = new Uint8Array(await event.request.arrayBuffer())
-  switch (event.request.headers.get(DISPATCH_HEADER)) {
+export async function postHandler(
+  ctx: Ctx,
+  op: string,
+  input: Uint8Array,
+): Promise<Response> {
+  switch (op) {
     case OP_PUT:
-      return handle(put, input)
+      return handle(put, input, ctx)
     case OP_RANDOM:
-      return handle(random, input)
+      return handle(random, input, ctx)
     case OP_NOW:
-      return handle(now, input)
+      return handle(now, input, ctx)
     default:
       return new Response(MP.encode('unknown op'), { status: 500 })
   }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,14 +1,31 @@
+// vim: set syntax=javascript:
+
 const path = require('path')
 const webpack = require('webpack')
 
-const mode = process.env.NODE_ENV || 'production'
+let mode = 'production'
+let devtool = false
+if (process.env.NODE_ENV === 'development') {
+  mode = 'development'
+  devtool = 'inline-source-map'
+}
 
 module.exports = {
-  output: {
-    filename: `worker.${mode}.js`,
-    path: path.join(__dirname, 'dist'),
-  },
   mode,
+  devtool,
+  output: {
+    publicPath: './',
+    module: true,
+    filename: `worker.js`,
+    path: path.join(__dirname, 'dist'),
+    library: {
+      type: 'module',
+    },
+    environment: {
+      module: true,
+      dynamicImport: true,
+    },
+  },
   resolve: {
     extensions: ['.ts', '.tsx', '.mjs', '.js'],
     plugins: [],
@@ -24,5 +41,8 @@ module.exports = {
         },
       },
     ],
+  },
+  experiments: {
+    outputModule: true,
   },
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,7 +10,15 @@ compatibility_date = "2022-01-14"
 [build]
 command = "npm ci && npm run build"
 [build.upload]
-format = "service-worker"
+dir    = "./dist"
+format = "modules"
+main   = "./worker.js"
+[[build.upload.rules]]
+globs = ["**/*.js"]
+type  = "ESModule"
+[[build.upload.rules]]
+globs = ["**/*.wasm"]
+type  = "CompiledWasm"
 
 [env.dev]
 name = "bootstrap-dev"


### PR DESCRIPTION
DEPENDS ON https://github.com/holochain/bootstrap/pull/16

Cloudflare now supports a new worker upload format called "modules" which makes it possible to use webassembly. This PR is in preparation for that, all it does is switch to this upload format.

- instead of `addEventListener('fetch', ..` we need to export a default fetch function
- the kv `BOOTSTRAP` is no longer attached to the global object, but instead passed into this exported fetch function