### PR TITLE
bootstrap metrics

### DIFF
--- a/integration/integration.ts
+++ b/integration/integration.ts
@@ -90,6 +90,7 @@ describe('integration tests', () => {
   it.only('should trigger_scheduled / metrics correctly', async function () {
     this.timeout(0)
 
+    // add some random agents to 3 different spaces
     for (let s = 0; s < 3; ++s) {
       let space = Uint8Array.from(Array(36).fill(s))
       for (let a = 0; a < 3; ++a) {
@@ -118,6 +119,7 @@ describe('integration tests', () => {
       }
     }
 
+    // trigger the scheduled aggregation 3 times
     for (let i = 0; i < 3; ++i) {
       await fetch(url, {
         method: 'POST',
@@ -128,6 +130,7 @@ describe('integration tests', () => {
       })
     }
 
+    // pull down the aggregated metrics
     const raw = await fetch(url, {
       method: 'GET',
       headers: {
@@ -139,7 +142,10 @@ describe('integration tests', () => {
       throw new Error(JSON.stringify(raw))
     }
 
+    // decode as json
     const res = JSON.parse((new TextDecoder()).decode(await raw.buffer()))
+
+    // print for debugging
     console.log(res)
 
     // make sure we only got 1 entry for the three triggers above

--- a/integration/integration.ts
+++ b/integration/integration.ts
@@ -87,7 +87,7 @@ describe('integration tests', () => {
     ], res.sort())
   })
 
-  it.only('should trigger_scheduled / metrics correctly', async function () {
+  it('should trigger_scheduled / metrics correctly', async function () {
     this.timeout(0)
 
     // add some random agents to 3 different spaces

--- a/integration/integration.ts
+++ b/integration/integration.ts
@@ -1,6 +1,8 @@
 import * as fetch from 'node-fetch'
 import { assert } from 'chai'
 import * as Agents from '../test/fixture/agents'
+import { keypair } from '../test/fixture/crypto'
+import * as Crypto from '../src/crypto/crypto'
 import { vaporChatSpace, wikiSpace, emptySpace } from '../test/fixture/spaces'
 import * as MP from '../src/msgpack/msgpack'
 import * as Kitsune from '../src/kitsune/kitsune'
@@ -83,6 +85,74 @@ describe('integration tests', () => {
       'https://test.holo.host/this/is/a/test?noodle=true',
       'https://test2.holo.host/another/test/this/is?a=b#yada',
     ], res.sort())
+  })
+
+  it.only('should trigger_scheduled / metrics correctly', async function () {
+    this.timeout(0)
+
+    for (let s = 0; s < 3; ++s) {
+      let space = Uint8Array.from(Array(36).fill(s))
+      for (let a = 0; a < 3; ++a) {
+        const {publicKey, secretKey} = keypair()
+        const info = {
+          space,
+          agent: Agents.publicKeyToKitsuneAgent(publicKey),
+          urls: ['https://foo.com'],
+          signed_at_ms: Date.now(),
+          expires_after_ms: 100000,
+          meta_info: new Uint8Array(0),
+        }
+        const infoEnc = MP.encode(info)
+        const signed = MP.encode({
+          signature: Crypto.sign(infoEnc, secretKey),
+          agent: info.agent,
+          agent_info: infoEnc,
+        })
+        await fetch(url, {
+          method: 'POST',
+          body: signed,
+          headers: {
+            'X-Op': 'put',
+          },
+        })
+      }
+    }
+
+    for (let i = 0; i < 3; ++i) {
+      await fetch(url, {
+        method: 'POST',
+        body: new Uint8Array(0),
+        headers: {
+          'X-Op': 'trigger_scheduled',
+        },
+      })
+    }
+
+    const raw = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'X-Op': 'metrics',
+      },
+    })
+
+    if (raw.status !== 200) {
+      throw new Error(JSON.stringify(raw))
+    }
+
+    const res = JSON.parse((new TextDecoder()).decode(await raw.buffer()))
+    console.log(res)
+
+    // make sure we only got 1 entry for the three triggers above
+    assert.equal(1, res.data.length)
+
+    // make sure we have at least the agents we added
+    assert(res.data[0][1] >= 9)
+
+    // make sure we have at least the spaces we added
+    assert(res.data[0][2] >= 3)
+
+    // make sure we recorded the two proxy urls in the proxy pool
+    assert.equal(2, res.data[0][3])
   })
 
   it('should POST correctly', async function () {

--- a/integration/integration.ts
+++ b/integration/integration.ts
@@ -92,7 +92,7 @@ describe('integration tests', () => {
 
     // add some random agents to 3 different spaces
     for (let s = 0; s < 3; ++s) {
-      let space = Uint8Array.from(Array(36).fill(s))
+      let space = Uint8Array.from(Array(36).fill(100 - s))
       for (let a = 0; a < 3; ++a) {
         const {publicKey, secretKey} = keypair()
         const info = {

--- a/rust/holochain_bootstrap_core/src/exec_scheduled.rs
+++ b/rust/holochain_bootstrap_core/src/exec_scheduled.rs
@@ -1,6 +1,60 @@
+use crate::metrics::*;
 use crate::types::*;
+use crate::PROXY_PREFIX;
+
+use alloc::boxed::Box;
+
+const HOUR: i64 = 60 * 60;
 
 /// Execute periodic scheduled logic
-pub async fn exec_scheduled(_kv: &dyn AsKV) -> BCoreResult<()> {
+pub async fn exec_scheduled(kv: &dyn AsKV, host: &dyn AsFromHost) -> BCoreResult<()> {
+    let cur_bucket = (host.get_timestamp_millis()? / 1000 / HOUR) * HOUR;
+    let cur_bucket_key = format!("{}{}", METRIC_PREFIX, cur_bucket);
+
+    let metric_key_list = kv.list(Some(METRIC_PREFIX)).await?;
+
+    for metric_key in metric_key_list {
+        if metric_key == cur_bucket_key {
+            // we've already aggregated this bucket, don't do the work again.
+            // note, this is not an atomic check, it's possible we'll still
+            // do the work again, but this mitigates that chance, and it's
+            // not a big deal if it's done multiple times.
+            return Ok(());
+        }
+    }
+
+    let mut metrics = Metrics::default();
+    let mut space_set = alloc::collections::BTreeSet::new();
+
+    // progressive list because this list could be huge
+    // and we don't have that much memory in wasm
+    kv.list_progressive(
+        None,
+        Box::new(|keys| {
+            for key in keys.drain(..) {
+                let key = key.as_bytes();
+                if &key[..METRIC_PREFIX.as_bytes().len()] == METRIC_PREFIX.as_bytes() {
+                    // ignore
+                } else if &key[..PROXY_PREFIX.as_bytes().len()] == PROXY_PREFIX.as_bytes() {
+                    metrics.total_proxy_count += 1;
+                } else {
+                    let space = &key[..key.len() / 2];
+                    let space =
+                        base64::decode(space).map_err(|e| BCoreError::from(format!("{:?}", e)))?;
+                    space_set.insert(space);
+                    metrics.total_agent_count += 1;
+                }
+            }
+
+            Ok(())
+        }),
+    )
+    .await?;
+    metrics.total_space_count = space_set.len() as u64;
+
+    const ONE_WEEK_S: f64 = 60.0 * 60.0 * 24.0 * 7.0;
+    kv.put(&cur_bucket_key, &metrics.encode(), ONE_WEEK_S)
+        .await?;
+
     Ok(())
 }

--- a/rust/holochain_bootstrap_core/src/exec_scheduled.rs
+++ b/rust/holochain_bootstrap_core/src/exec_scheduled.rs
@@ -1,0 +1,6 @@
+use crate::types::*;
+
+/// Execute periodic scheduled logic
+pub async fn exec_scheduled(_kv: &dyn AsKV) -> BCoreResult<()> {
+    Ok(())
+}

--- a/rust/holochain_bootstrap_core/src/handlers.rs
+++ b/rust/holochain_bootstrap_core/src/handlers.rs
@@ -1,6 +1,10 @@
 //! Built-in common bootstrap handlers
 
+const METHOD_GET: &str = "GET";
 const METHOD_POST: &str = "POST";
+
+mod get_metrics;
+pub use get_metrics::*;
 
 mod post_put;
 pub use post_put::*;

--- a/rust/holochain_bootstrap_core/src/handlers.rs
+++ b/rust/holochain_bootstrap_core/src/handlers.rs
@@ -7,3 +7,6 @@ pub use post_put::*;
 
 mod post_proxy_list;
 pub use post_proxy_list::*;
+
+mod post_trigger_scheduled;
+pub use post_trigger_scheduled::*;

--- a/rust/holochain_bootstrap_core/src/handlers/get_metrics.rs
+++ b/rust/holochain_bootstrap_core/src/handlers/get_metrics.rs
@@ -1,0 +1,66 @@
+use crate::metrics::*;
+use crate::types::*;
+
+const OP_METRICS: &str = "metrics";
+
+/// Handler for method: "GET", op: "metrics".
+pub struct GetMetrics;
+
+impl AsRequestHandler for GetMetrics {
+    fn handles_method(&self) -> &'static str {
+        super::METHOD_GET
+    }
+
+    fn handles_op(&self) -> &'static str {
+        OP_METRICS
+    }
+
+    fn handle<'a>(
+        &'a self,
+        kv: &'a dyn AsKV,
+        _host: &'a dyn AsFromHost,
+        input: &'a [u8],
+    ) -> BCoreFut<'a, BCoreResult<HttpResponse>> {
+        bcore_fut(async move {
+            if !input.is_empty() {
+                return Err("body must be empty for 'GET/metrics'".into());
+            }
+
+            let mut body = alloc::vec::Vec::new();
+            body.extend_from_slice(
+                br#"{
+  "header": ["timestamp", "total_agent_count", "total_space_count", "total_proxy_count"],
+  "data": ["#,
+            );
+
+            let entries = kv.list(Some(METRIC_PREFIX)).await?;
+            let mut first = true;
+            for key in entries {
+                let val = kv.get(&key).await?;
+                let val = Metrics::decode(&val);
+                if first {
+                    first = false;
+                    body.extend_from_slice(b"\n    [");
+                } else {
+                    body.extend_from_slice(b",\n    [");
+                }
+                body.extend_from_slice(&key.as_bytes()[METRIC_PREFIX.len()..]);
+                body.extend_from_slice(
+                    &format!(
+                        ", {}, {}, {}]",
+                        val.total_agent_count, val.total_space_count, val.total_proxy_count,
+                    )
+                    .into_bytes(),
+                );
+            }
+
+            body.extend_from_slice(b"\n  ]\n}\n");
+
+            Ok(HttpResponse {
+                status: 200,
+                headers: vec![("content-type".into(), "application/json".into())],
+                body,
+            })
+        })
+    }
+}

--- a/rust/holochain_bootstrap_core/src/handlers/post_proxy_list.rs
+++ b/rust/holochain_bootstrap_core/src/handlers/post_proxy_list.rs
@@ -18,6 +18,7 @@ impl AsRequestHandler for PostProxyList {
     fn handle<'a>(
         &'a self,
         kv: &'a dyn AsKV,
+        _host: &'a dyn AsFromHost,
         input: &'a [u8],
     ) -> BCoreFut<'a, BCoreResult<HttpResponse>> {
         bcore_fut(async move {
@@ -25,7 +26,7 @@ impl AsRequestHandler for PostProxyList {
                 return Err("body must be empty for 'POST/proxy_list'".into());
             }
 
-            let entries = kv.list(Some("proxy_pool:")).await?;
+            let entries = kv.list(Some(crate::PROXY_PREFIX)).await?;
 
             let mut enc = msgpackin_core::encode::Encoder::new();
             let mut body = alloc::vec::Vec::new();

--- a/rust/holochain_bootstrap_core/src/handlers/post_put.rs
+++ b/rust/holochain_bootstrap_core/src/handlers/post_put.rs
@@ -19,6 +19,7 @@ impl AsRequestHandler for PostPut {
     fn handle<'a>(
         &'a self,
         _kv: &'a dyn AsKV,
+        _host: &'a dyn AsFromHost,
         input: &'a [u8],
     ) -> BCoreFut<'a, BCoreResult<HttpResponse>> {
         bcore_fut(async move {

--- a/rust/holochain_bootstrap_core/src/handlers/post_trigger_scheduled.rs
+++ b/rust/holochain_bootstrap_core/src/handlers/post_trigger_scheduled.rs
@@ -1,0 +1,37 @@
+use crate::types::*;
+
+const OP_PROXY_LIST: &str = "trigger_scheduled";
+
+/// Handler for method: "POST", op: "trigger_scheduled".
+/// Manually trigger the "scheduled" cron event
+pub struct PostTriggerScheduled;
+
+impl AsRequestHandler for PostTriggerScheduled {
+    fn handles_method(&self) -> &'static str {
+        super::METHOD_POST
+    }
+
+    fn handles_op(&self) -> &'static str {
+        OP_PROXY_LIST
+    }
+
+    fn handle<'a>(
+        &'a self,
+        kv: &'a dyn AsKV,
+        input: &'a [u8],
+    ) -> BCoreFut<'a, BCoreResult<HttpResponse>> {
+        bcore_fut(async move {
+            if !input.is_empty() {
+                return Err("body must be empty for 'POST/trigger_scheduled'".into());
+            }
+
+            crate::exec_scheduled(kv).await?;
+
+            Ok(HttpResponse {
+                status: 200,
+                headers: vec![("content-type".into(), "text/plain".into())],
+                body: b"Ok".to_vec(),
+            })
+        })
+    }
+}

--- a/rust/holochain_bootstrap_core/src/handlers/post_trigger_scheduled.rs
+++ b/rust/holochain_bootstrap_core/src/handlers/post_trigger_scheduled.rs
@@ -18,6 +18,7 @@ impl AsRequestHandler for PostTriggerScheduled {
     fn handle<'a>(
         &'a self,
         kv: &'a dyn AsKV,
+        host: &'a dyn AsFromHost,
         input: &'a [u8],
     ) -> BCoreFut<'a, BCoreResult<HttpResponse>> {
         bcore_fut(async move {
@@ -25,7 +26,7 @@ impl AsRequestHandler for PostTriggerScheduled {
                 return Err("body must be empty for 'POST/trigger_scheduled'".into());
             }
 
-            crate::exec_scheduled(kv).await?;
+            crate::exec_scheduled(kv, host).await?;
 
             Ok(HttpResponse {
                 status: 200,

--- a/rust/holochain_bootstrap_core/src/lib.rs
+++ b/rust/holochain_bootstrap_core/src/lib.rs
@@ -16,3 +16,6 @@ pub use dispatcher::*;
 pub mod agent_info;
 
 pub mod handlers;
+
+mod exec_scheduled;
+pub use exec_scheduled::*;

--- a/rust/holochain_bootstrap_core/src/lib.rs
+++ b/rust/holochain_bootstrap_core/src/lib.rs
@@ -8,6 +8,10 @@
 #[macro_use]
 extern crate alloc;
 
+pub(crate) const PROXY_PREFIX: &str = "proxy_pool:";
+
+pub(crate) mod metrics;
+
 pub mod types;
 
 mod dispatcher;

--- a/rust/holochain_bootstrap_core/src/metrics.rs
+++ b/rust/holochain_bootstrap_core/src/metrics.rs
@@ -1,0 +1,60 @@
+use alloc::vec::Vec;
+
+/// kv prefix for metric entries
+pub const METRIC_PREFIX: &str = "bootstrap_metric:";
+
+/// single metric entry structure
+#[derive(Default)]
+pub struct Metrics {
+    pub total_agent_count: u64,
+    pub total_space_count: u64,
+    pub total_proxy_count: u64,
+}
+
+impl Metrics {
+    /// msgpack encode this metric entry
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(64);
+        let mut enc = msgpackin_core::encode::Encoder::new();
+        out.extend_from_slice(&enc.enc_arr_len(3));
+        out.extend_from_slice(&enc.enc_num(self.total_agent_count));
+        out.extend_from_slice(&enc.enc_num(self.total_space_count));
+        out.extend_from_slice(&enc.enc_num(self.total_proxy_count));
+        out
+    }
+
+    /// msgpack decode this metric entry
+    #[allow(dead_code)]
+    pub fn decode(data: &[u8]) -> Self {
+        use msgpackin_core::decode::*;
+
+        let mut out = Metrics::default();
+        let mut dec = Decoder::new();
+        let mut iter = dec.parse(data);
+        let mut len = match iter.next() {
+            Some(Token::Len(LenType::Arr, len)) => len,
+            _ => return out,
+        };
+        match iter.next() {
+            Some(Token::Num(n)) => out.total_agent_count = n.to(),
+            _ => return out,
+        };
+        len -= 1;
+        if len == 0 {
+            return out;
+        }
+        match iter.next() {
+            Some(Token::Num(n)) => out.total_space_count = n.to(),
+            _ => return out,
+        };
+        len -= 1;
+        if len == 0 {
+            return out;
+        }
+        match iter.next() {
+            Some(Token::Num(n)) => out.total_proxy_count = n.to(),
+            _ => return out,
+        };
+        out
+    }
+}

--- a/rust/holochain_bootstrap_wasm/src/host.rs
+++ b/rust/holochain_bootstrap_wasm/src/host.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+pub struct Host(JsValue);
+
+impl Host {
+    pub fn new(host: JsValue) -> JsResult<Self> {
+        Ok(Host(host))
+    }
+
+    /// Internal helper for getting a specific function from the KV object
+    fn get_func_prop(&self, name: &str) -> BCoreResult<js_sys::Function> {
+        let func: JsValue =
+            js_sys::Reflect::get(&self.0, &name.into()).map_err(|e| bcore_err!("{:?}", e))?;
+        if !func.is_function() {
+            return Err(format!("{} is not a function", name).into());
+        }
+        Ok(func.into())
+    }
+}
+
+impl AsFromHost for Host {
+    fn get_timestamp_millis(&self) -> BCoreResult<i64> {
+        let func = self.get_func_prop("get_timestamp_millis")?;
+        let res = func.call0(&self.0).map_err(|e| bcore_err!("{:?}", e))?;
+        let res = res
+            .as_f64()
+            .ok_or_else(|| BCoreError::from("expected num"))?;
+        Ok(res as i64)
+    }
+}

--- a/rust/holochain_bootstrap_wasm/src/lib.rs
+++ b/rust/holochain_bootstrap_wasm/src/lib.rs
@@ -19,6 +19,15 @@ pub type JsResult<T> = core::result::Result<T, JsValue>;
 mod kv;
 use kv::*;
 
+/// Handle a scheduled event
+#[wasm_bindgen]
+pub async fn handle_scheduled(kv: JsValue) -> JsResult<()> {
+    let kv = KV::new(kv)?;
+    exec_scheduled(&kv)
+        .await
+        .map_err(|e| format!("{:?}", e).into())
+}
+
 /// Handle an incoming request building up a response
 #[wasm_bindgen]
 pub async fn handle_request(
@@ -31,6 +40,7 @@ pub async fn handle_request(
     let mut dispatch = HandlerDispatcher::new(kv);
     dispatch.attach_handler(handlers::PostPut);
     dispatch.attach_handler(handlers::PostProxyList);
+    dispatch.attach_handler(handlers::PostTriggerScheduled);
 
     let method = method
         .as_string()

--- a/rust/holochain_bootstrap_wasm/src/lib.rs
+++ b/rust/holochain_bootstrap_wasm/src/lib.rs
@@ -19,11 +19,15 @@ pub type JsResult<T> = core::result::Result<T, JsValue>;
 mod kv;
 use kv::*;
 
+mod host;
+use host::*;
+
 /// Handle a scheduled event
 #[wasm_bindgen]
-pub async fn handle_scheduled(kv: JsValue) -> JsResult<()> {
+pub async fn handle_scheduled(kv: JsValue, host: JsValue) -> JsResult<()> {
     let kv = KV::new(kv)?;
-    exec_scheduled(&kv)
+    let host = Host::new(host)?;
+    exec_scheduled(&kv, &host)
         .await
         .map_err(|e| format!("{:?}", e).into())
 }
@@ -32,12 +36,15 @@ pub async fn handle_scheduled(kv: JsValue) -> JsResult<()> {
 #[wasm_bindgen]
 pub async fn handle_request(
     kv: JsValue,
+    host: JsValue,
     method: JsValue,
     op: JsValue,
     input: JsValue,
 ) -> JsResult<JsValue> {
     let kv = KV::new(kv)?;
-    let mut dispatch = HandlerDispatcher::new(kv);
+    let host = Host::new(host)?;
+    let mut dispatch = HandlerDispatcher::new(kv, host);
+    dispatch.attach_handler(handlers::GetMetrics);
     dispatch.attach_handler(handlers::PostPut);
     dispatch.attach_handler(handlers::PostProxyList);
     dispatch.attach_handler(handlers::PostTriggerScheduled);

--- a/scripts/cf_worker_entry.js
+++ b/scripts/cf_worker_entry.js
@@ -4,5 +4,8 @@ import workerIndex from './worker.js'
 export default {
   fetch: async (request, env) => {
     return await workerIndex.fetch(request, env, bootstrapWasm)
+  },
+  scheduled: async (_event, env, _ctx) => {
+    await workerIndex.scheduled(env, bootstrapWasm)
   }
 }

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -1,6 +1,11 @@
+export interface WasmHost {
+  get_timestamp_millis: () => number
+}
+
 export interface BootstrapWasm {
   handle_request: (
     kv: KVNamespace,
+    host: WasmHost,
     method: string,
     op: string,
     input: Uint8Array,
@@ -10,10 +15,16 @@ export interface BootstrapWasm {
     body: Uint8Array
   }>
 
-  handle_scheduled: (kv: KVNamespace) => Promise<void>
+  handle_scheduled: (kv: KVNamespace, host: WasmHost) => Promise<void>
+}
+
+export const wasmHost = {
+  get_timestamp_millis: Date.now.bind(Date),
 }
 
 export class Ctx {
+  public wasmHost: WasmHost = wasmHost
+
   constructor(
     public request: Request,
     public BOOTSTRAP: KVNamespace,

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -9,6 +9,8 @@ export interface BootstrapWasm {
     headers: Array<[string, string]>
     body: Uint8Array
   }>
+
+  handle_scheduled: (kv: KVNamespace) => Promise<void>
 }
 
 export class Ctx {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { BootstrapWasm, Ctx } from './ctx'
+import { BootstrapWasm, Ctx, wasmHost } from './ctx'
 import { requestDispatch } from './request/dispatch'
 
 export default {
@@ -15,6 +15,6 @@ export default {
     env: { BOOTSTRAP: KVNamespace },
     bootstrapWasm: BootstrapWasm,
   ): Promise<void> {
-    await bootstrapWasm.handle_scheduled(env.BOOTSTRAP)
+    await bootstrapWasm.handle_scheduled(env.BOOTSTRAP, wasmHost)
   },
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,11 @@ export default {
     const ctx = new Ctx(request, env.BOOTSTRAP, bootstrapWasm)
     return await requestDispatch(ctx)
   },
+
+  async scheduled(
+    env: { BOOTSTRAP: KVNamespace },
+    bootstrapWasm: BootstrapWasm,
+  ): Promise<void> {
+    await bootstrapWasm.handle_scheduled(env.BOOTSTRAP)
+  },
 }

--- a/src/request/dispatch.ts
+++ b/src/request/dispatch.ts
@@ -1,14 +1,20 @@
 import { Ctx } from '../ctx'
 import { postHandler } from './post'
 
+function opFromPath(url: string): string {
+  const res = new RegExp('\\/([^\\/]*)', 'g').exec(new URL(url).pathname)
+  return Array.isArray(res) && typeof res[1] === 'string' ? res[1] : ''
+}
+
 export async function requestDispatch(ctx: Ctx): Promise<Response> {
   const method = ctx.request.method
-  const op = ctx.request.headers.get('X-Op') || ''
+  const op = ctx.request.headers.get('X-Op') || opFromPath(ctx.request.url)
   const input = new Uint8Array(await ctx.request.arrayBuffer())
 
   try {
     const response = await ctx.bootstrapWasm.handle_request(
       ctx.BOOTSTRAP,
+      ctx.wasmHost,
       method,
       op,
       input,

--- a/src/request/dispatch.ts
+++ b/src/request/dispatch.ts
@@ -2,7 +2,7 @@ import { Ctx } from '../ctx'
 import { postHandler } from './post'
 
 function opFromPath(url: string): string {
-  const res = new RegExp('\\/([^\\/]*)', 'g').exec(new URL(url).pathname)
+  const res = new RegExp('^\\/([^\\/]*)').exec(new URL(url).pathname)
   return Array.isArray(res) && typeof res[1] === 'string' ? res[1] : ''
 }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,10 +9,9 @@ compatibility_date = "2022-01-14"
 
 [triggers]
 # trigger scheduled tasks like metrics aggregation
-# internally, only one aggregation will happen per hour, having the
-# idempotent trigger run more frequently just ensures the metrics will
-# be aggregated sometime at the beginning of the hour. plus, 29 is prime
-crons = ["*/29 * * * *"]
+# internally, only one aggregation will happen per hour
+# setting this to run at 15 to make sure we're within the hour bucket
+crons = ["15 * * * *"]
 
 [build]
 command = "npm ci && npm run build"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,6 +7,9 @@ workers_dev = true
 vars = { ENVIRONMENT = "dev" }
 compatibility_date = "2022-01-14"
 
+[triggers]
+crons = ["*/13 * * * *"]
+
 [build]
 command = "npm ci && npm run build"
 [build.upload]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,11 @@ vars = { ENVIRONMENT = "dev" }
 compatibility_date = "2022-01-14"
 
 [triggers]
-crons = ["*/53 * * * *"]
+# trigger scheduled tasks like metrics aggregation
+# internally, only one aggregation will happen per hour, having the
+# idempotent trigger run more frequently just ensures the metrics will
+# be aggregated sometime at the beginning of the hour. plus, 29 is prime
+crons = ["*/29 * * * *"]
 
 [build]
 command = "npm ci && npm run build"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,7 @@ vars = { ENVIRONMENT = "dev" }
 compatibility_date = "2022-01-14"
 
 [triggers]
-crons = ["*/13 * * * *"]
+crons = ["*/53 * * * *"]
 
 [build]
 command = "npm ci && npm run build"


### PR DESCRIPTION
- Implements a cloudflare scheduled cron trigger for running metrics aggregation ~once per hour
- Implements a POST/trigger_scheduled manual trigger for that idempotent cron trigger mainly for testing
- Implements a GET/metrics handler to dump the aggregated metrics as json:

```json
{
  "header": ["timestamp", "total_agent_count", "total_space_count", "total_proxy_count"],
  "data": [
    [1645646400, 0, 0, 0],
    [1645650000, 9, 3, 2]
  ]
}
```